### PR TITLE
`PS1_time` now shows current time

### DIFF
--- a/prompt.sh
+++ b/prompt.sh
@@ -18,7 +18,7 @@ x_bottom="$blue└"
 x_cross="$red✗"
 x_tick="$greenb✓"
 
-PS1_time="$x_top(${orange}15:18$blue)"
+PS1_time="$x_top(${orange}$(date '+%H:%M')$blue)"
 PS1_cwd="$x_center($cyanb\w$reset$blue)"
 #PS1_user="$x_center($gray\u$blue)"
 #PS1_user_host="$x_center($gray\u$reset@$gray\h$blue)"


### PR DESCRIPTION
In my opinion the clock should not always indicate 15:18 😁
If I'm wrong, I'm sorry 🤭
p.s I haven't tried it on linux yet